### PR TITLE
fix: disable auto-translation of text fields like title and author

### DIFF
--- a/src/components/Header/PlaybackCtrl/DisplayCtrl/DisplayCtrl.tsx
+++ b/src/components/Header/PlaybackCtrl/DisplayCtrl/DisplayCtrl.tsx
@@ -114,6 +114,7 @@ const DisplayCtrl = ({
                     id='visualizer-preset-name'
                     className={styles.presetName}
                     aria-live='polite'
+                    translate='no'
                   >
                     {visualizerPresetName}
                   </p>

--- a/src/routes/Account/components/Prefs/PathPrefs/PathChooser/PathChooser.tsx
+++ b/src/routes/Account/components/Prefs/PathPrefs/PathChooser/PathChooser.tsx
@@ -72,7 +72,7 @@ const PathChooser = ({ onCancel, onChoose }: PathChooserProps) => {
         </div>
       )}
     >
-      <div className={styles.container}>
+      <div className={styles.container} translate='no'>
         <div className={styles.folderCurrent}>
           {pathInfo.current || '\u00a0'}
         </div>

--- a/src/routes/Account/components/Rooms/Rooms.tsx
+++ b/src/routes/Account/components/Rooms/Rooms.tsx
@@ -36,7 +36,7 @@ const Rooms = () => {
     const room = rooms.entities[roomId]
     return (
       <tr key={String(roomId)}>
-        <td><a data-room-id={roomId} onClick={handleOpen}>{room.name}</a></td>
+        <td translate='no'><a data-room-id={roomId} onClick={handleOpen}>{room.name}</a></td>
         <td>
           {room.status}
           {room.numUsers > 0 && (

--- a/src/routes/Account/components/Users/Users.tsx
+++ b/src/routes/Account/components/Users/Users.tsx
@@ -40,7 +40,7 @@ const Users = () => {
     return (
       <tr key={userId}>
         {userId === curUserId && (
-          <td>
+          <td translate='no'>
             <strong>{user.username}</strong>
             {' '}
             (

--- a/src/routes/Library/components/ArtistItem/ArtistItem.tsx
+++ b/src/routes/Library/components/ArtistItem/ArtistItem.tsx
@@ -32,7 +32,7 @@ const ArtistItem = ({
   const isChildStarred = artistSongIds.some(songId => starredSongs.includes(songId))
 
   return (
-    <div style={style}>
+    <div style={style} translate='no'>
       <div onClick={onArtistClick} className={clsx(styles.container, isChildStarred && styles.hasStarred)}>
         <div className={styles.folderContainer}>
           <Icon icon='FOLDER' />

--- a/src/routes/Player/components/PlayerTextOverlay/UpNow/UpNow.tsx
+++ b/src/routes/Player/components/PlayerTextOverlay/UpNow/UpNow.tsx
@@ -58,7 +58,7 @@ const UpNow = ({ queueItem }: UpNowProps) => {
         exitActive: styles.exitActive,
       }}
     >
-      <div ref={nodeRef} className={styles.container}>
+      <div ref={nodeRef} className={styles.container} translate='no'>
         <div className={styles.innerContainer}>
           <UserImage
             userId={queueItem.userId}

--- a/src/routes/Queue/components/QueueItem/QueueItem.tsx
+++ b/src/routes/Queue/components/QueueItem/QueueItem.tsx
@@ -131,7 +131,7 @@ const QueueItem = ({
           </div>
         </div>
 
-        <div className={clsx(styles.primary, isPlayed && styles.greyed)}>
+        <div className={clsx(styles.primary, isPlayed && styles.greyed)} translate='no'>
           <div className={styles.innerPrimary}>
             <div className={styles.title}>{title}</div>
             <div className={styles.artist}>{artist}</div>


### PR DESCRIPTION
This PR prevents translation of text elements, that should not be auto translated to foreign languages such as:

- Song Title
- Author
- File Names
- Room Names