### PR TITLE
fix: use correct password when signing room as guest

### DIFF
--- a/src/routes/Account/views/SignedOutView/SignedOutView.tsx
+++ b/src/routes/Account/views/SignedOutView/SignedOutView.tsx
@@ -98,7 +98,7 @@ const SignedOutView = () => {
     data.append('newPassword', password)
     data.append('newPasswordConfirm', passwordConfirm)
     data.append('roomId', String(roomId))
-    data.append('roomPassword', password)
+    data.append('roomPassword', roomPassword)
     data.append('name', name.trim())
 
     if (typeof image !== 'undefined') {


### PR DESCRIPTION
## What Changed
* Usage correct password when signing room as guest

## Known limitations
* None (that I'm aware)